### PR TITLE
リポジトリのURL修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/cloudlatex-team/cloudlatex-vscode-extension.git"
+    "url": "https://github.com/cloudlatex-team/cloudlatex-vscode-extension.git"
   },
   "homepage": "https://github.com/cloudlatex-team/cloudlatex-vscode-extension",
   "keywords": [


### PR DESCRIPTION
マーケットプレースのページからリポジトリに飛べない問題を解消するため、リポジトリのURLを修正します。