### PR TITLE
PRでもCIが動作するようにする・Node.jsアップデート

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,7 @@ on:
     branches:
     - 'master'
     - 'release'
+  pull_request:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Setup NodeJs
       uses: actions/setup-node@v1
       with:
-        node-version: '10.x'
+        node-version: '16.x'
     - name: Cache node_modules
       uses: actions/cache@preview
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Setup NodeJs
       uses: actions/setup-node@v1
       with:
-        node-version: '1.x'
+        node-version: '14.x'
     - name: Cache node_modules
       uses: actions/cache@preview
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Setup NodeJs
       uses: actions/setup-node@v1
       with:
-        node-version: '16.x'
+        node-version: '1.x'
     - name: Cache node_modules
       uses: actions/cache@preview
       with:


### PR DESCRIPTION
masterやreleaseへのpush時だけでなく、PRでもCIが動作するようにします。
また、以下のようにCIが失敗するので、Node.jsをアップデートします。

https://github.com/cloudlatex-team/cloudlatex-vscode-extension/runs/5005818912?check_suite_focus=true

```
error vsce@2.6.5: The engine "node" is incompatible with this module. Expected version ">= 14". Got "10.24.1"
error Found incompatible module.
```