### PR TITLE
Feature ignore files option

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,12 +71,60 @@ If the download is successful, a dialog box will appear indicating that the file
 
 | Setting key              | Description                                                                         | Default  | Type      |
 | -------------------------| ----------------------------------------------------------------------------------- | -------- | --------- |
-| `cloudlatex.enabled`     | Set true if enable cloudlatex plugin in this project                                | `false`  | _boolean_ |
+| `cloudlatex.enabled`     | Set true to enable cloudlatex plugin in this project                                | `false`  | _boolean_ |
 | `cloudlatex.projectId`   | ProjectId. *Do not mistake this value, otherwise your files might be overwritten    | `0`      | _number_  |
 | `cloudlatex.outDir`      | Directory to output compile result                                                  | `""`     | _string_  |
-| `cloudlatex.autoCompile` | Set true if automatically compile when any files are saved                          | `true`   | _boolean_ |
+| `cloudlatex.autoCompile` | Set true to automatically compile when any files are saved                          | `true`   | _boolean_ |
 | `cloudlatex.supressIcon` | Set true to hide cloudlatex icon on the activity bar in the unactivated project     | `false`  | _boolean_ |
+| `cloudlatex.ignoreFiles` | Files to be ignored from file synchronization | See the next section  | _Array\<string\>_ |
 
+
+### Specifying files not to be synchronized
+Files matching the glob pattern specified in `cloudlatex.ignoreFiles` are ignored from the file synchronization process. The glob patterns are matched against the absolute file pattern. 
+Patterns are compatible with [anymatch](https://github.com/micromatch/anymatch).
+
+Example: `**/README.md` , `**/*.bin`
+
+By default, file names starting with `.` except for `.latexmkrc` and extensions related to LaTeX compiled artifacts are set.  
+For performance reasons, `.git` and `node_modules` are also ignored from the file synchronization process, regardless of `cloudlatex.ignoreFiles`.
+
+<details>
+<summary>Default value of cloudlatex.ignoreFiles </summary>
+
+```
+[
+  "**/*.aux",
+  "**/*.bbl",
+  "**/*.bcf",
+  "**/*.blg",
+  "**/*.idx",
+  "**/*.ind",
+  "**/*.lof",
+  "**/*.lot",
+  "**/*.out",
+  "**/*.toc",
+  "**/*.acn",
+  "**/*.acr",
+  "**/*.alg",
+  "**/*.glg",
+  "**/*.glo",
+  "**/*.gls",
+  "**/*.ist",
+  "**/*.fls",
+  "**/*.log",
+  "**/*.nav",
+  "**/*.snm",
+  "**/*.fdb_latexmk",
+  "**/*.synctex.gz",
+  "**/*.synctex\\(busy\\)",
+  "**/*.synctex.gz\\(busy\\)",
+  "**/*.run.xml",
+  "**/.vscode/**",
+  "**/.!(latexmkrc)*"
+]
+```
+
+</details>
 
 # Source Code
 https://github.com/cloudlatex-team/cloudlatex-vscode-extension/tree/main

--- a/docs/README_ja.md
+++ b/docs/README_ja.md
@@ -89,6 +89,55 @@
 | `cloudlatex.outDir`      | コンパイル成果物出力先ディレクトリ                                                  | `""`     | _string_  |
 | `cloudlatex.autoCompile` | 自動コンパイルを有効にするかどうか                          | `true`   | _boolean_ |
 | `cloudlatex.supressIcon` | `true` にするとLaTeXプロジェクト以外のプロジェクトではActivity BarにCLアイコンが表示されなくなります     | `false`  | _boolean_ |
+| `cloudlatex.ignoreFiles` | 同期を行わないファイルを指定    | 次項参照  | _Array\<string\>_ |
+
+### 同期を行わないファイルの指定
+`cloudlatex.ignoreFiles` で指定されたglobパターンにマッチしたファイルはファイル同期処理から無視されます。  **絶対ファイルパス** に対してパターンのマッチング処理が行われます。
+指定できるパターンは [anymatch](https://github.com/micromatch/anymatch)と互換性があります。
+
+例: `**/README.md` , `**/*.bin`
+
+デフォルトでは `.latexmkrc` を除く `.`から始まるファイル名とLaTeXのコンパイル成果物に関係する拡張子が指定されています。
+またパフォーマンス上の理由から `cloudlatex.ignoreFiles` の設定値によらず、`.git`, `node_modules`は常に同期されません。
+
+<details>
+<summary>cloudlatex.ignoreFiles のデフォルト値 </summary>
+
+```
+[
+  "**/*.aux",
+  "**/*.bbl",
+  "**/*.bcf",
+  "**/*.blg",
+  "**/*.idx",
+  "**/*.ind",
+  "**/*.lof",
+  "**/*.lot",
+  "**/*.out",
+  "**/*.toc",
+  "**/*.acn",
+  "**/*.acr",
+  "**/*.alg",
+  "**/*.glg",
+  "**/*.glo",
+  "**/*.gls",
+  "**/*.ist",
+  "**/*.fls",
+  "**/*.log",
+  "**/*.nav",
+  "**/*.snm",
+  "**/*.fdb_latexmk",
+  "**/*.synctex.gz",
+  "**/*.synctex\\(busy\\)",
+  "**/*.synctex.gz\\(busy\\)",
+  "**/*.run.xml",
+  "**/.vscode/**",
+  "**/.!(latexmkrc)*"
+]
+```
+
+</details>
+
 
 ## UI言語設定
 VSCodeの言語設定で日本語が設定されている場合は当拡張機能のUIも日本語表示になります。

--- a/package.json
+++ b/package.json
@@ -92,6 +92,41 @@
           "type": "string",
           "default": "https://cloudlatex.io/api",
           "description": "API endpoint. *Do not edit this value under normal usage."
+        },
+        "cloudlatex.ignoreFiles": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [
+            "**/*.aux",
+            "**/*.bbl",
+            "**/*.bcf",
+            "**/*.blg",
+            "**/*.idx",
+            "**/*.ind",
+            "**/*.lof",
+            "**/*.lot",
+            "**/*.out",
+            "**/*.toc",
+            "**/*.acn",
+            "**/*.acr",
+            "**/*.alg",
+            "**/*.glg",
+            "**/*.glo",
+            "**/*.gls",
+            "**/*.ist",
+            "**/*.fls",
+            "**/*.log",
+            "**/*.nav",
+            "**/*.snm",
+            "**/*.fdb_latexmk",
+            "**/*.synctex.gz",
+            "**/*.run.xml",
+            "**/.vscode/**",
+            "**/.!(latexmkrc)*"
+          ],
+          "description": "Ignore file patterns"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -122,6 +122,8 @@
             "**/*.snm",
             "**/*.fdb_latexmk",
             "**/*.synctex.gz",
+            "**/*.synctex\\(busy\\)",
+            "**/*.synctex.gz\\(busy\\)",
             "**/*.run.xml",
             "**/.vscode/**",
             "**/.!(latexmkrc)*"

--- a/src/const.ts
+++ b/src/const.ts
@@ -1,18 +1,21 @@
+import { VSConfig } from './type';
+
 export const EXTENSION_NAME = 'cloudlatex';
 
 export const DATA_TREE_PROVIDER_ID = 'cloudlatex-commands';
 export const STATUS_BAR_TEXT = 'CL';
 
-export const CONFIG_NAMES = {
+export const CONFIG_NAMES: { [k in keyof VSConfig]: `${typeof EXTENSION_NAME}.${keyof VSConfig}` } = {
   enabled: `${EXTENSION_NAME}.enabled`,
   outDir: `${EXTENSION_NAME}.outDir`,
   autoCompile: `${EXTENSION_NAME}.autoCompile`,
   endpoint: `${EXTENSION_NAME}.endpoint`,
   projectId: `${EXTENSION_NAME}.projectId`,
-  supressIcon: `${EXTENSION_NAME}.supressIcon`
+  supressIcon: `${EXTENSION_NAME}.supressIcon`,
+  ignoreFiles: `${EXTENSION_NAME}.ignoreFiles`,
 };
 
-export const COMMAND_NAMES = {
+export const COMMAND_NAMES: { [k: string]: `${typeof EXTENSION_NAME}.${string}` } = {
   refreshEntry: `${EXTENSION_NAME}.refreshEntry`,
   openHelpPage: `${EXTENSION_NAME}.openHelpPage`,
   compile: `${EXTENSION_NAME}.compile`,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -17,7 +17,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
   vscode.workspace.onDidChangeConfiguration(async (e) => {
     if (
-      [CONFIG_NAMES.enabled, CONFIG_NAMES.outDir, CONFIG_NAMES.autoCompile, CONFIG_NAMES.endpoint, CONFIG_NAMES.projectId]
+      [CONFIG_NAMES.enabled, CONFIG_NAMES.outDir, CONFIG_NAMES.autoCompile, CONFIG_NAMES.endpoint, CONFIG_NAMES.projectId, CONFIG_NAMES.ignoreFiles]
         .some(name => e.affectsConfiguration(name))
     ) {
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -147,7 +147,7 @@ class VSLatexApp {
     });
 
     this.latexApp.on(LATEX_APP_EVENTS.FILE_CHANGE_ERROR, (detail: string) => {
-      vscode.window.showErrorMessage('File change error', detail);
+      vscode.window.showErrorMessage(localeStr(MESSAGE_TYPE.FILE_CHANGE_ERROR));
     });
 
     this.latexApp.on(LATEX_APP_EVENTS.COMPILATION_STARTED, () => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -403,7 +403,7 @@ class VSLatexApp {
 
   obtainAccountPath(): string {
     // global storage path to save account data and global meta data.
-    const globalStoragePath = this.context.globalStoragePath;
+    const globalStoragePath = this.context.globalStorageUri.fsPath;
     fs.promises.mkdir(globalStoragePath).catch(() => {
       // directory is already created
     });
@@ -467,7 +467,7 @@ class VSLatexApp {
   }
 
   getStoragePath(): string | undefined {
-    return this.context.storagePath;
+    return this.context.storageUri?.fsPath;
   }
 
   get sideBarInfo(): SideBarInfo {

--- a/src/type.ts
+++ b/src/type.ts
@@ -6,7 +6,8 @@ export type VSConfig = {
   autoCompile: boolean,
   endpoint: string,
   projectId: number,
-  supressIcon: boolean
+  supressIcon: boolean,
+  ignoreFiles: Array<string>,
 };
 
 export type SideBarInfo = {

--- a/src/vslogger.ts
+++ b/src/vslogger.ts
@@ -25,7 +25,7 @@ export default class VSLogger extends Logger {
 
   _appendToLogPanel(type: string, m: any, ...o: any[]) {
     const now = new Date();
-    const timeStr = dateformat(now, 'hh:MM:ss');
+    const timeStr = dateformat(now, 'HH:MM:ss');
     const message = [m, ...(o || [])].map(o => {
       if (typeof o === 'string') {
         return o;


### PR DESCRIPTION
## 動作確認
- [x] デフォルトの ignoreFiles の設定で `.env`  ファイルをローカルに作成しても同期されない
- [x] デフォルトの ignoreFiles の設定で  `.latexmkrc` を作成すると同期される
- [x] `.git`, `node_modules`  (設定値によらず必ず無視されるファイル)が同期されない
- [x] コンパイル出力先としてプロジェクト直下を指定した (`outDir` = ``)際に出力結果 (`xx.pdf`, `xxx.log`, `xxx.synctex`) がサーバ側に同期されない
- [x] コンパイル出力先としてプロジェクト直下の子ディレクトリ(`outDir` = `out`)を指定した際に出力結果が同期されない

### ファイル操作網羅テスト
- [x] (aa) ローカルに `test.tex` を作成してリモートに同期された後、ignoreFiles に `**/test.tex` を追加、その後ignoreFiles から `**/test.tex` を削除すると同期が再開されconflict dialog が表示される
- [x] (ab) ignoreFiles に `**/test.tex` を追加、その後サーバに `test.tex` を追加する、この時点ではローカルに同期されないが ignoreFiles から `**/test.tex` を削除すると同期が再開されローカルに `test.tex` が生成される
- [x] (ac) ローカルに `test.tex` を作成してリモートに同期された後、ignoreFiles に `**/test.tex` を追加、その後リモートの `test.tex` の内容を更新する、この時点ではローカルに同期されないがignoreFiles から `**/test.tex` を削除すると同期が再開されconflict dialogが表示
- [x] (ad) ローカルに `test.tex` を作成してリモートに同期された後、ignoreFiles に `**/test.tex` を追加、その後リモートの `test.tex` の内容を削除する、この時点ではローカルの `test.tex` は削除されないがignoreFiles から `**/test.tex` を削除すると同期が再開されremoteに `test.tex` がアップロードされる
- [x] (ba) ignoreFiles に `**/test.tex` を追加、その後ローカルに `test.tex` を追加する、この時点ではリモートに同期されないが ignoreFiles から `**/test.tex` を削除すると同期が再開されリモートに `test.tex` が生成される
- [x] (bb) ignoreFiles に `**/test.tex` を追加、その後ローカルとリモートに `test.tex` を追加する、その後 ignoreFiles から `**/test.tex` を削除すると同期が再開されコンフリクトダイアログが表示される
- [x] (ca) ローカルに `test.tex` を作成してリモートに同期された後、ignoreFiles に `**/test.tex` を追加、その後ローカルの `test.tex` の内容を更新する、この時点ではリモートに同期されないがignoreFiles から `**/test.tex` を削除すると同期が再開されリモートの `test.tex` が更新される
- [x] (cc) ローカルに `test.tex` を作成してリモートに同期された後、ignoreFiles に `**/test.tex` を追加、その後ローカルとリモートの `test.tex` の内容をそれぞれ更新する、この時点では同期されないがignoreFiles から `**/test.tex` を削除すると同期が再開されコンフリクトダイアログが表示される
- [x] (cd) ローカルに `test.tex` を作成してリモートに同期された後、ignoreFiles に `**/test.tex` を追加、その後ローカルの `test.tex` を更新しリモートの `test.tex` を削除する、この時点では同期されないがignoreFiles から `**/test.tex` を削除すると同期が再開されlocalの `test.tex` がremoteに uploadされる
- [x] (da) ローカルに `test.tex` を作成してリモートに同期された後、ignoreFiles に `**/test.tex` を追加、その後ローカルの `test.tex` を削除する、この時点では同期されないがignoreFiles から `**/test.tex` を削除すると同期が再開されリモートの `test.tex` がローカルにダウンロードされる
- [x]  (dc) ローカルに `test.tex` を作成してリモートに同期された後、ignoreFiles に `**/test.tex` を追加、その後ローカルの `test.tex` を削除しリモートの `test.tex` を更新する、この時点では同期されないがignoreFiles から `**/test.tex` を削除すると同期が再開されremoteの `test.tex` がローカルにダウンロードされる
- [x] (dd) ローカルに `test.tex` を作成してリモートに同期された後、ignoreFiles に `**/test.tex` を追加、その後ローカルとリモートの `test.tex` を削除する、 `**/test.tex` を削除しても何も起きない

| ローカル \ サーバ | 何もしない | ファイル作成 | ファイル更新 | ファイル削除 | 
| :---------------- | ---------- | ------------ | ------------ | ------------ | 
| 何もしない        |  (aa)        |   (ab)          |     (ac)         |    (ad)        | 
| ファイル作成    |  (ba)        |  (bb)          |                    |              | 
| ファイル更新    |   (ca)        |                 |    (cc)         |    (cd)        | 
| ファイル削除    |   (da)       |                 |    (dc)          |    (dd)       | 

### フォルダー操作網羅テスト
- [x] (aa) 
- [x] (ab) 
- [x] (ac) 
- [x] (ba)
- [x] (bb)
- [x] (ca)
- [x] (cc)

| ローカル \ サーバ | 何もしない | フォルダ作成  | フォルダ削除 | 
| :---------------- | ---------- | ------------ | ------------ | 
| 何もしない            |  (aa)          |   (ab)            |     (ac)           | 
| フォルダ作成        |  (ba)           |  (bb)             |                       |
| フォルダ削除        |   (ca)          |                      |    (cc)            |
