### PR TITLE
CI: Actionsアップデート

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,9 +17,9 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Setup NodeJs
-      uses: actions/setup-node@v2.5.1
+      uses: actions/setup-node@v4
       with:
         node-version: '18.x'
         cache: yarn
@@ -32,7 +32,7 @@ jobs:
     - name: build vsce
       run: yarn run vsce
     - name: Archive vsce result
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: vsce file
         path: build


### PR DESCRIPTION
https://github.com/cloudlatex-team/cloudlatex-vscode-extension/actions/runs/6754965147

```
The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2, actions/setup-node@v2.5.1, actions/upload-artifact@v2. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
```

```
The `save-state` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```

```
The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```

GitHub Actionsにおいて、node 12や `set-state`, `set-output` は非推奨なので、Actionsをアップデートします。