### PR TITLE
Fix English translation errors and typos

### DIFF
--- a/package.nls.json
+++ b/package.nls.json
@@ -14,6 +14,6 @@
   "cloudlatex.command.setting": "Setting",
   "cloudlatex.command.viewCompilerError": "View Compile Error",
   "cloudlatex.command.compilerLog": "View Compiler Log",
-  "cloudlatex.command.viewPDF": "View LaTeX PDF",
+  "cloudlatex.command.viewPDF": "View PDF",
   "cloudlatex.command.setTarget": "Set As LaTeX Compile Target"
 }

--- a/src/locale/en.ts
+++ b/src/locale/en.ts
@@ -12,31 +12,31 @@ export const enTranslation: Translation = {
   VIEW_LOG: 'View Log',
   RELOAD: 'Reload',
   OFFLINE: 'Offline',
-  VIEW_PDF: 'View LaTeX PDF',
+  VIEW_PDF: 'View PDF',
 
   DETAIL: 'Detail',
   NO_WORKSPACE_ERROR: 'No workspace found. Please open a workspace first.',
   LOGIN_SUCCEEDED: 'Login to Cloud LaTeX succeeded.',
   LOGIN_FAILED: `Login to Cloud LaTeX failed. 
-  Please generate a token from the Cloud LaTeX web site and enter the generated token from the \'Set Account\' button on the lower right.
-  (* The token will be deactivated after a certain period of time. In that case, you need to generate token again.)`,
-  OFFLINE_ERROR: `The network is offline or some trouble occur with the server.
+  Please generate a token from the Cloud LaTeX website and enter the generated token using the \'Set Account\' button in the lower right.
+  (* The token will be deactivated after a certain period of time. In that case, you need to generate a new token.)`,
+  OFFLINE_ERROR: `The network is offline or some trouble has occurred with the server.
   You can edit your files, but your changes will not be reflected on the server
-  until it is enable to communicate with the server.`,
+  until communication with the server is restored.`,
   COMPILATION_FAILED: 'Compilation failed.',
   FILE_SYNC_FAILED: 'File synchronization failed',
   FILE_SYNCHRONIZED: 'Project files have been synchronized!',
-  FILE_CHANGE_ERROR: 'File change error happened.',
-  UNEXPECTED_ERROR: 'Unexpected error happend.',
-  FILE_CONFLICT_DETECTED: 'Following files is both changed in the server and local:',
-  CONFIG_ENABLED_PLACE_ERROR: `Be sure to set ${CONFIG_NAMES.enabled} to true not at user\'s settings but at workspace settings.`,
-  CONFIG_PROJECTID_EMPTY_ERROR: 'ProjectId should be set in workspace configration file.',
+  FILE_CHANGE_ERROR: 'Unexpected file change was detected.',
+  UNEXPECTED_ERROR: 'Unexpected error happened.',
+  FILE_CONFLICT_DETECTED: 'The following files have been changed both on the server and locally:',
+  CONFIG_ENABLED_PLACE_ERROR: `Be sure to set ${CONFIG_NAMES.enabled} to true in workspace settings, not in user settings.`,
+  CONFIG_PROJECTID_EMPTY_ERROR: 'ProjectId should be set in the workspace configuration file.',
   HOW_TO_GENERATE_TOKEN: 'How to generate token',
   SETTING_README_URL: 'https://github.com/cloudlatex-team/cloudlatex-vscode-extension#setting',
   CHECK_DETAILS: 'Check details',
   NO_COMPILATION_TARGET: 'Compilation target is not set',
-  UNKNOWN_ERROR: 'Unknown error happens',
+  UNKNOWN_ERROR: 'An unknown error has occurred',
   PROJECT_UPDATED: 'Project setting has been updated',
-  FIRST_SYNC_NOTIFICATION: 'Do you want to sync the project \'$project_name\' ?',
+  FIRST_SYNC_NOTIFICATION: 'Do you want to sync the project \'$project_name\'?',
   NOT_EMPTY_DIRECTORY: 'The directory contains files. To prevent overwriting files, the directory to be synchronized must be empty.'
 };


### PR DESCRIPTION
## 概要
英語翻訳の誤訳、スペルミス、文法エラーを修正しました。

## 変更内容
- **スペルミス修正**:
  - `happend` → `happened`
  - `configration` → `configuration`

- **文法・表現の改善**:
  - `LOGIN_FAILED`: より自然な英語表現に修正
  - `OFFLINE_ERROR`: 文法エラーを修正
  - `FILE_CONFLICT_DETECTED`: より適切な英語表現に修正
  - `CONFIG_ENABLED_PLACE_ERROR`: より自然な表現に修正
  - その他複数の文法的な問題を修正

- **意味の整合性**:
  - `FILE_CHANGE_ERROR`: 日本語版と意味を合わせる
  - 日本語版と英語版の翻訳の一貫性を向上

- **ファイル間の一貫性**:
  - `package.nls.json` と `en.ts` で "View LaTeX PDF" → "View PDF" に統一

## 修正したファイル
- `src/locale/en.ts`
- `package.nls.json`

## テスト
- 翻訳文字列の表示確認
- 文法チェック完了

## 関連Issue
ユーザーフィードバック「当方VSCodeを英語設定で利用しているのですが、ところどころに誤訳のようなものが見られる」への対応