### PR TITLE
Fix GitHub Actions build error by updating Node.js to 20.x

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Setup NodeJs
       uses: actions/setup-node@v4
       with:
-        node-version: '18.x'
+        node-version: '20.x'
         cache: yarn
     - name: Install Dependencies
       run: yarn install --frozen-lockfile


### PR DESCRIPTION
## 概要
GitHub Actions のビルドエラーを修正しました。

## 問題
GitHub Actions で `yarn add vsce` を実行する際に、以下のエラーが発生していました：
```
error cheerio@1.1.2: The engine "node" is incompatible with this module. 
Expected version ">=20.18.1". Got "18.20.8"
```

## 原因
- GitHub Actions で Node.js 18.x を使用していた
- `vsce` パッケージの依存関係である `cheerio@1.1.2` が Node.js ≥20.18.1 を要求

## 修正内容
- `.github/workflows/main.yml` の Node.js バージョンを `18.x` から `20.x` に更新

## 変更したファイル
- `.github/workflows/main.yml`

## テスト
- GitHub Actions でビルドが成功することを確認予定

## 備考
- `package.json` の `engines.vscode` は変更していません（既存ユーザーへの影響を最小化）
- Node.js 20 への更新は GitHub Actions のみで、ローカル開発環境には影響しません